### PR TITLE
allow extensions to be killed by docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN python -m pip install /log_parser $(for imp in ${EXTENSIONS}; do echo "-r /l
 RUN mkdir /log-parser-bin && \
     for imp in ${EXTENSIONS}; do \
         echo '#!/bin/sh' > "/log-parser-bin/log-parser-${imp}" && \
-        echo "python /log_parser/extensions/${imp}/cli.py" '"$@"' >> "/log-parser-bin/log-parser-${imp}" && \
+        echo "exec python /log_parser/extensions/${imp}/cli.py" '"$@"' >> "/log-parser-bin/log-parser-${imp}" && \
         chmod u+x "/log-parser-bin/log-parser-${imp}"; \
     done
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "log_parser"
-version = "1.1.0"
+version = "1.1.1"
 description = "A simple asynchronous log file parsing library"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Previously, the extension scripts created by the Dockerfile would run the log parser code as a subprocess of the main process (PID 1 in the container). 

This meant that when the container was stopped, a SIGTERM would be sent to PID 1 which would be killed but the signal would not be passed on to the actual log parser code. This would mean that the log parser code would keep running until the container itself was killed with a SIGKILL.

This changes the extension script to use `exec` so that the log parser code runs in the main process (PID 1 in the container) so that it can be stopped by a SIGTERM as expected.